### PR TITLE
switch to login-action for quay.io login as...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -20,8 +20,12 @@ jobs:
       uses: actions/checkout@v2
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker Quay.io Login"
-      run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+    - name: "Docker quay.io Login"
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: "Run build script"
       run:  ./build.sh
     - name: "Docker Push"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:  ./build.sh
     - name: "Docker Push"
       run: |
-       docker push quay.io/eclipse/che-workspace-data-sync-storage:latest
-       docker push quay.io/eclipse/che-sidecar-workspace-data-sync:latest
+       docker push quay.io/eclipse/che-workspace-data-sync-storage:next
+       docker push quay.io/eclipse/che-sidecar-workspace-data-sync:next
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Create branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -1,4 +1,11 @@
-
+# 
+# Copyright (c) 2020-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
 name: Create branch
 on:
   # to be run once every 3 weeks for a 7.yy.0 release, so we can get a stable 7.yy.x branch for use by downstream consumers

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
     branches: [ release ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: "Checkout workspace-data-sync source code"
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -19,8 +19,12 @@ jobs:
       uses: actions/checkout@v2
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker Quay.io Login"
-      run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+    - name: "Docker quay.io Login"
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: "Run build script"
       run:  ./build.sh
     - name: "Run release script: push images to the quay.io and create tag on GitHub"


### PR DESCRIPTION
### What does this PR do?

switch to login-action for quay.io login as commandline docker login not working

Change-Id: I8e87a5547277eebb05a9694d420294ca737a05b2
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

Commits to this repo are failing to push to quay.
https://github.com/che-incubator/workspace-data-sync/runs/4359200985?check_suite_focus=true

Turns out it's because re removed an old bot user from quay and didn't update this repo to use the new gh_actions one.

https://github.com/che-incubator/workspace-data-sync/runs/4385489814?check_suite_focus=true is running now after a successful login, using the updated secrets.

But we should still switch from deprecated/unsafe commandline flags to the login-action for consistency w/ other projects. 

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.