### PR TITLE
fix: backports from main for CRW 2.14 / 7.40.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -20,13 +20,17 @@ jobs:
       uses: actions/checkout@v2
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker Quay.io Login"
-      run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+    - name: "Docker quay.io Login"
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: "Run build script"
       run:  ./build.sh
     - name: "Docker Push"
       run: |
-       docker push quay.io/eclipse/che-workspace-data-sync-storage:latest
-       docker push quay.io/eclipse/che-sidecar-workspace-data-sync:latest
+       docker push quay.io/eclipse/che-workspace-data-sync-storage:next
+       docker push quay.io/eclipse/che-sidecar-workspace-data-sync:next
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,16 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: "Run build script"
-      run:  ./build.sh
+      run:  ./build.sh --tag next
     - name: "Docker Push"
       run: |
+       SHORT_SHA1=$(git rev-parse --short HEAD)
+       docker tag quay.io/eclipse/che-workspace-data-sync-storage:next quay.io/eclipse/che-workspace-data-sync-storage:${SHORT_SHA1}
+       docker tag quay.io/eclipse/che-sidecar-workspace-data-sync:next quay.io/eclipse/che-sidecar-workspace-data-sync:${SHORT_SHA1}
+       docker push quay.io/eclipse/che-workspace-data-sync-storage:${SHORT_SHA1}
+       docker push quay.io/eclipse/che-sidecar-workspace-data-sync:${SHORT_SHA1}
        docker push quay.io/eclipse/che-workspace-data-sync-storage:next
        docker push quay.io/eclipse/che-sidecar-workspace-data-sync:next
+
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -1,4 +1,11 @@
-
+# 
+# Copyright (c) 2020-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
 name: Create branch
 on:
   # to be run once every 3 weeks for a 7.yy.0 release, so we can get a stable 7.yy.x branch for use by downstream consumers
@@ -16,7 +23,7 @@ on:
 jobs:
   build:
     name: Create branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -13,14 +13,18 @@ on:
     branches: [ release ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: "Checkout workspace-data-sync source code"
       uses: actions/checkout@v2
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker Quay.io Login"
-      run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
+    - name: "Docker quay.io Login"
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     - name: "Run build script"
       run:  ./build.sh
     - name: "Run release script: push images to the quay.io and create tag on GitHub"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/build.sh
+++ b/build.sh
@@ -13,14 +13,14 @@
 usage="$(basename "$0") -- script for compile Go source and build docker images
 
 usage:
-    -t,--tag             tag name for docker images (default: latest)
+    -t,--tag             tag name for docker images (default: next)
     -o,--organization    organization name for docker images (default: eclipse)
     -r,--repository      docker registry (default quay.io)
     -h,--help            show this help text"
 
 #default
 ORGANIZATION="eclipse"
-TAG="latest"
+TAG="next"
 REPOSITORY="quay.io"
 
 while [[ $# -gt 0 ]]

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/server/Dockerfile
+++ b/dockerfiles/server/Dockerfile
@@ -1,36 +1,35 @@
-#!/bin/bash
-#
-# Copyright (c) 2019-2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
 
 FROM alpine:3.11
 
-COPY  entrypoint.sh /usr/local/bin
+COPY entrypoint.sh /usr/local/bin
+COPY sshd_config /etc/ssh/sshd_config
 
 RUN mkdir /etc/ssh /var/run/sshd /.ssh \
-    && touch /.ssh/known_hosts \
-    # Change permissions to let any arbitrary user
-    && for f in  "/etc/ssh" "/etc/passwd" "/.ssh" "/var/run/sshd" ; do \
-        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
-        chmod -R g+rwX ${f}; \
-       done \
     && apk update \
     && apk upgrade \
     && apk add --no-cache \
             rsync \
             openssh \
             ca-certificates \
-    && update-ca-certificates \
+    && touch /.ssh/known_hosts \
     && rm -rf /var/cache/apk/* /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key \
+    # Change permissions to let any arbitrary user
+    && for f in  "/etc/ssh" "/etc/passwd" "/.ssh" "/var/run/sshd" ; do \
+        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+        chmod -R g+rwX ${f}; \
+       done \
+    && update-ca-certificates \
     && chmod 0550 /.ssh \
     && chmod 0777 /.ssh/known_hosts \
     && sed -i s/root:!/"root:*"/g /etc/shadow \
     && chmod +x /usr/local/bin/entrypoint.sh
 
-COPY sshd_config /etc/ssh/sshd_config
 EXPOSE 2222
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]

--- a/dockerfiles/server/entrypoint.sh
+++ b/dockerfiles/server/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2019-2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/server/ubi.Dockerfile
+++ b/dockerfiles/server/ubi.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 Red Hat, Inc.
+# Copyright (c) 2020-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,10 +7,11 @@
 # 
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.redhat.io/ubi8/ubi-minimal:8.3-230
+FROM registry.redhat.io/ubi8-minimal:8.5-204
 
-ADD content_sets_centos8.repo /etc/yum.repos.d/
-COPY  entrypoint.sh /usr/local/bin
+COPY content_sets_centos8.repo /etc/yum.repos.d/
+COPY entrypoint.sh /usr/local/bin
+COPY sshd_config /etc/ssh/sshd_config
 
 RUN mkdir /etc/ssh /var/run/sshd /.ssh \
     && microdnf update -y \
@@ -32,6 +33,5 @@ RUN mkdir /etc/ssh /var/run/sshd /.ssh \
     && sed -i s/root:!/"root:*"/g /etc/shadow \
     && chmod +x /usr/local/bin/entrypoint.sh
 
-COPY sshd_config /etc/ssh/sshd_config
 EXPOSE 2222
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
### What does this PR do?

* f868d98 - fix: default tag should be next, not latest; (#16) nboldt@redhat.com (45 seconds ago)
* 9cf2a3b - switch to login-action for quay.io login as... (#15) nboldt@redhat.com (45 seconds ago)
* 0efee9d - fix: set realistic copyright dates (project started in 2020, not 2012 oe 2019) nboldt@redhat.com (66 seconds ago)
* 6a5d1b7 - reorder dockerfile steps so ubi.Dockerfile and Dockerfile do things the same order (easier maintenance)

Change-Id: I3df528b4bf94c395eddab479a14d9e5d7e282bf9
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.