### PR TITLE
Use proper ubi8 image name

### DIFF
--- a/dockerfiles/sidecar/ubi.Dockerfile
+++ b/dockerfiles/sidecar/ubi.Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: EPL-2.0
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.redhat.io/ubi8/ubi-minimal:8.3-230
+FROM registry.redhat.io/ubi8-minimal:8.5-204
 
 ENV USER=user \
     UID=12345 \


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

Use same ubi8minimal image name as in the Server image (version 8.5), as the base image update job will correctly update this image in the future.