### PR TITLE
Use multistage container build to compile Go

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,5 +53,4 @@ do
     esac
 done
 
-compile;
 dockerBuild "${TAG}" "${ORGANIZATION}";

--- a/common.sh
+++ b/common.sh
@@ -14,16 +14,6 @@ TAG=$1
 ORGANIZATION=$2
 REPOSITORY=$3
 
-function compile() {
-  echo "Compile file sync progress watcher binary from source code"
-  $(GOOS=linux go build -o ./dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go)
-  if [ $? != 0 ]; then
-    echo "Failed to compile code"
-    exit 0
-  fi
-  echo "Compilation successfully completed"
-}
-
 function dockerBuild() {
   printf "Build docker image %s/%s/%s:%s \n" "$REPOSITORY" "$ORGANIZATION" "$IMAGE_SIDECAR" "$TAG";
   docker build -t "$REPOSITORY/$ORGANIZATION/$IMAGE_SIDECAR:$TAG" ./dockerfiles/sidecar

--- a/dockerfiles/sidecar/Dockerfile
+++ b/dockerfiles/sidecar/Dockerfile
@@ -7,6 +7,13 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
+FROM golang:1.16.0-alpine as builder
+ENV GOPATH=/tmp/go/
+
+WORKDIR /workspace-data-sync/
+COPY . .
+RUN go mod tidy && go build -o ./dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go
+
 FROM alpine:3.11
 
 ENV USER=user \
@@ -19,8 +26,9 @@ ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
     SUPERCRONIC=supercronic-linux-amd64 \
     SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
 
-COPY cron/backup-cron-job /etc/crontabs/backup-cron-job
-COPY scripts scripts
+COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go
+COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/cron/backup-cron-job /etc/crontabs/backup-cron-job
+COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts /scripts
 
 # Add user that will be able to start watcher binary but nothing more
 # the result will be propagated then into scratch image

--- a/dockerfiles/sidecar/Dockerfile
+++ b/dockerfiles/sidecar/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /workspace-data-sync/
 COPY . .
 RUN go mod tidy && go build -o ./dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go
 
-FROM alpine:3.11
+FROM alpine:3.13
 
 ENV USER=user \
     UID=12345 \
@@ -30,7 +30,7 @@ COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/cron/backup-cron-jo
 COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts /scripts
 
 # Add user that will be able to start watcher binary but nothing more
-# the result will be propagated then into scratch image
+# the result will be propagated then into runtime image
 # See https://stackoverflow.com/a/55757473/12429735RUN
 RUN addgroup --gid "$GID" "$USER" \
        && adduser \

--- a/dockerfiles/sidecar/Dockerfile
+++ b/dockerfiles/sidecar/Dockerfile
@@ -26,7 +26,6 @@ ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
     SUPERCRONIC=supercronic-linux-amd64 \
     SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
 
-COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go
 COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/cron/backup-cron-job /etc/crontabs/backup-cron-job
 COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts /scripts
 

--- a/dockerfiles/sidecar/ubi.Dockerfile
+++ b/dockerfiles/sidecar/ubi.Dockerfile
@@ -22,22 +22,18 @@ ENV USER=user \
     GROUP=group \
     GID=23456
 
-
-
 #cron task not work in openshift in case https://github.com/gliderlabs/docker-alpine/issues/381
 #so will used  supercronic https://github.com/aptible/supercronic
 ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
     SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
 
-COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts/watcher ./watcher/watcher.go
 COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/cron/backup-cron-job /etc/crontabs/backup-cron-job
 COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts /scripts
 
-COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/content_sets_centos8.repo /etc/yum/repos.d/content_sets_centos8.repo 
 #
 # Add user that will be able to start watcher binary but nothing more
-# the result will be propagated then into scratch image
+# the result will be propagated then into alpine image
 # See https://stackoverflow.com/a/55757473/12429735RUN
 #
 RUN microdnf update -y \ 

--- a/dockerfiles/sidecar/ubi.Dockerfile
+++ b/dockerfiles/sidecar/ubi.Dockerfile
@@ -33,7 +33,7 @@ COPY --from=builder /workspace-data-sync/dockerfiles/sidecar/scripts /scripts
 
 #
 # Add user that will be able to start watcher binary but nothing more
-# the result will be propagated then into alpine image
+# the result will be propagated then into runtime image
 # See https://stackoverflow.com/a/55757473/12429735RUN
 #
 RUN microdnf update -y \ 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/che-incubator/workspace-data-sync
 
-go 1.12
+go 1.16
 
 require github.com/gorilla/websocket v1.4.2


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

related to https://issues.redhat.com/browse/CRW-1422

Compile Go code in container build stage (for better reliability and simpler productization)