### PR TITLE
Use project root as context for dockerfile builds

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -16,14 +16,14 @@ REPOSITORY=$3
 
 function dockerBuild() {
   printf "Build docker image %s/%s/%s:%s \n" "$REPOSITORY" "$ORGANIZATION" "$IMAGE_SIDECAR" "$TAG";
-  docker build -t "$REPOSITORY/$ORGANIZATION/$IMAGE_SIDECAR:$TAG" ./dockerfiles/sidecar
+  docker build -t "$REPOSITORY/$ORGANIZATION/$IMAGE_SIDECAR:$TAG" . -f dockerfiles/sidecar/Dockerfile
   if [ $? != 0 ]; then
     printf "Failed build docker image %s/%s/%s:%s \n" "$REPOSITORY" "$ORGANIZATION" "$IMAGE_SIDECAR" "$TAG";
     exit 0
   fi
 
   printf "Build docker image %s/%s/%s:%s \n" "$REPOSITORY" "$ORGANIZATION" "$IMAGE_SERVER" "$TAG";
-  docker build -t "$REPOSITORY/$ORGANIZATION/$IMAGE_SERVER:$TAG" ./dockerfiles/server
+  docker build -t "$REPOSITORY/$ORGANIZATION/$IMAGE_SERVER:$TAG" . -f dockerfiles/server/Dockerfile
   if [ $? != 0 ]; then
     printf "Failed build docker image %s/%s/%s:%s \n" "$REPOSITORY" "$ORGANIZATION" "$IMAGE_SERVER" "$TAG";
     exit 0

--- a/dockerfiles/server/Dockerfile
+++ b/dockerfiles/server/Dockerfile
@@ -8,8 +8,8 @@
 
 FROM alpine:3.11
 
-COPY entrypoint.sh /usr/local/bin
-COPY sshd_config /etc/ssh/sshd_config
+COPY dockerfiles/server/entrypoint.sh /usr/local/bin
+COPY dockerfiles/server/sshd_config /etc/ssh/sshd_config
 
 RUN mkdir -p /etc/ssh /var/run/sshd /.ssh \
     && apk update \

--- a/dockerfiles/server/ubi.Dockerfile
+++ b/dockerfiles/server/ubi.Dockerfile
@@ -9,9 +9,8 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.redhat.io/ubi8-minimal:8.5-204
 
-COPY content_sets_centos8.repo /etc/yum.repos.d/
-COPY entrypoint.sh /usr/local/bin
-COPY sshd_config /etc/ssh/sshd_config
+COPY dockerfiles/server/entrypoint.sh /usr/local/bin
+COPY dockerfiles/server/sshd_config /etc/ssh/sshd_config
 
 RUN mkdir -p /etc/ssh /var/run/sshd /.ssh \
     && microdnf update -y \


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

Use project root as context for container builds - make both images to use similar pattern and fix build.sh script